### PR TITLE
Fix tab bar button typing and expose Supabase config

### DIFF
--- a/strength_rank/components/haptic-tab.tsx
+++ b/strength_rank/components/haptic-tab.tsx
@@ -1,48 +1,17 @@
 // components/haptic-tab.tsx
 import * as React from 'react';
-import { Pressable, type PressableProps } from 'react-native';
+import { PlatformPressable } from '@react-navigation/elements';
+import type { BottomTabBarButtonProps } from '@react-navigation/bottom-tabs';
 import * as Haptics from 'expo-haptics';
 
-type TabBtnProps = {
-  children?: React.ReactNode;
-  style?: PressableProps['style'];
-  onPress?: () => void;
-  onLongPress?: () => void;
-  onPressIn?: () => void;
-  onPressOut?: () => void;
-  accessibilityRole?: PressableProps['accessibilityRole'];
-  testID?: string;
-  hitSlop?: PressableProps['hitSlop'];
-};
-
-export function HapticTab({
-  children,
-  style,
-  onPress,
-  onLongPress,
-  onPressIn,
-  onPressOut,
-  accessibilityRole = 'button',
-  testID,
-  hitSlop,
-}: TabBtnProps) {
-  const handlePressIn = React.useCallback(() => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
-    onPressIn?.();
-  }, [onPressIn]);
-
-  return (
-    <Pressable
-      accessibilityRole={accessibilityRole}
-      testID={testID}
-      hitSlop={hitSlop}
-      style={style}
-      onPress={onPress}
-      onLongPress={onLongPress}
-      onPressIn={handlePressIn}
-      onPressOut={onPressOut}
-    >
-      {children}
-    </Pressable>
+export function HapticTab({ onPressIn, style, ...rest }: BottomTabBarButtonProps) {
+  const handlePressIn = React.useCallback<NonNullable<BottomTabBarButtonProps['onPressIn']>>(
+    (event) => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
+      onPressIn?.(event);
+    },
+    [onPressIn],
   );
+
+  return <PlatformPressable {...rest} style={style} onPressIn={handlePressIn} />;
 }

--- a/strength_rank/lib/supabase.ts
+++ b/strength_rank/lib/supabase.ts
@@ -2,8 +2,8 @@
 import 'react-native-url-polyfill/auto';
 import { createClient } from '@supabase/supabase-js';
 
-const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
-const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+export const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
+export const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   throw new Error(


### PR DESCRIPTION
## Summary
- wrap the custom tab bar button with `PlatformPressable` so it satisfies `BottomTabBarButtonProps` while keeping haptic feedback
- export the Supabase environment constants for reuse in debug utilities

## Testing
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cd74ee07948329bd39fe0030da8400