### PR TITLE
Use runtime require for dev helpers

### DIFF
--- a/strength_rank/app/(tabs)/leaderboard.tsx
+++ b/strength_rank/app/(tabs)/leaderboard.tsx
@@ -18,15 +18,20 @@ import { ThemedView } from '@/components/themed-view';
 import { supabase } from '@/lib/supabase';
 
 // Optional helpers (dev sign-in / @you id)
-type DevHelpersModule = typeof import('@/lib/data');
+type DevHelpersModule = {
+  devSignIn?: () => Promise<unknown>;
+  getDevUserId?: () => Promise<string>;
+};
+
 let cachedDevHelpers: DevHelpersModule | null = null;
 let loadDevHelpersPromise: Promise<DevHelpersModule | null> | null = null;
 
 async function loadDevHelpers(): Promise<DevHelpersModule | null> {
   if (cachedDevHelpers) return cachedDevHelpers;
   if (!loadDevHelpersPromise) {
-    loadDevHelpersPromise = import('@/lib/data')
-      .then((mod) => {
+    loadDevHelpersPromise = Promise.resolve()
+      .then(() => {
+        const mod = require('@/lib/data') as DevHelpersModule;
         cachedDevHelpers = mod;
         return mod;
       })


### PR DESCRIPTION
## Summary
- replace the dynamic import of the dev helper utilities with a Promise-wrapped require to avoid Hermes issues
- define a minimal DevHelpersModule shape while keeping the caching logic intact

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68cd7b375e908329a791ef0832c3619e