### PR TITLE
Add gym tagging when saving PRs

### DIFF
--- a/strength_rank/lib/data.ts
+++ b/strength_rank/lib/data.ts
@@ -163,6 +163,7 @@ export async function savePRRow(opts: {
   bodyweightKg?: number | null;
   age?: number | null;
   videoUrl?: string | null;
+  gymId?: string | null;
 }) {
   const { error } = await supabase.from('lift_prs').insert({
     user_id: opts.userId,
@@ -172,6 +173,7 @@ export async function savePRRow(opts: {
     bodyweight_kg: opts.bodyweightKg ?? null,
     age_at_lift: opts.age ?? null,
     video_url: opts.videoUrl ?? null,
+    gym_id: opts.gymId ?? null,
     verify: 'unverified',
   });
   if (error) throw error;


### PR DESCRIPTION
## Summary
- allow saving PR rows with an optional gym id so the record is tied to a gym leaderboard
- add gym search and selection UI when adding a PR, including recently picked gyms
- pass the chosen gym id through the save flow so new PRs surface on the correct leaderboard

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d7e85319148329a27429d71e26ae85