### PR TITLE
Add performed_at timestamps when saving PR rows

### DIFF
--- a/strength_rank/app/(tabs)/add.tsx
+++ b/strength_rank/app/(tabs)/add.tsx
@@ -248,8 +248,18 @@ export default function AddPRScreen() {
         }
       }
 
+      const performedAt = new Date().toISOString();
+
       // insert PR row
-      await savePRRow({ userId, lift, weightKg: w, bodyweightKg: bw, age: a, videoUrl });
+      await savePRRow({
+        userId,
+        lift,
+        weightKg: w,
+        bodyweightKg: bw,
+        age: a,
+        videoUrl,
+        performedAt,
+      });
 
       // update UI: recompute improvements + append to local history
       const old = selectedOld ?? oldForLift[oldForLift.length - 1];
@@ -261,7 +271,7 @@ export default function AddPRScreen() {
       setResult({ old, newWeight: w, deltaKg, oldPct, newPct, deltaPct });
 
       // append to local history so charts update without refetch
-      const todayISO = new Date().toISOString().slice(0, 10);
+      const todayISO = performedAt.slice(0, 10);
       setOldForLift((cur) => [...cur, {
         id: `local-${Date.now()}`,
         date: todayISO,

--- a/strength_rank/lib/data.ts
+++ b/strength_rank/lib/data.ts
@@ -163,6 +163,7 @@ export async function savePRRow(opts: {
   bodyweightKg?: number | null;
   age?: number | null;
   videoUrl?: string | null;
+  performedAt?: string;
 }) {
   const { error } = await supabase.from('lift_prs').insert({
     user_id: opts.userId,
@@ -173,6 +174,7 @@ export async function savePRRow(opts: {
     age_at_lift: opts.age ?? null,
     video_url: opts.videoUrl ?? null,
     verify: 'unverified',
+    performed_at: opts.performedAt ?? new Date().toISOString(),
   });
   if (error) throw error;
 }


### PR DESCRIPTION
## Summary
- add an optional `performedAt` field to `savePRRow` and persist it when inserting
- update the Add tab to pass the recorded timestamp and reuse it for the local history entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7e84ec65c83298d9d737e871184f6