### PR TITLE
Hide leaderboard tab from bottom navigation

### DIFF
--- a/strength_rank/app/(tabs)/_layout.tsx
+++ b/strength_rank/app/(tabs)/_layout.tsx
@@ -25,8 +25,8 @@ export default function TabLayout() {
       <Tabs.Screen
         name="leaderboard"
         options={{
-          title: 'Leaderboard',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="trophy.fill" color={color} />,
+          // Hide from the tab bar but keep the route accessible via navigation.
+          href: null,
         }}
       />
       <Tabs.Screen


### PR DESCRIPTION
## Summary
- hide the leaderboard tab from the bottom navigation so it can only be reached via search

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9043bda9883299ce411582ef2165f