### PR TITLE
Add Supabase auth flow and session-aware navigation

### DIFF
--- a/strength_rank/app/_layout.tsx
+++ b/strength_rank/app/_layout.tsx
@@ -1,21 +1,100 @@
 import { DarkTheme, DefaultTheme, ThemeProvider as NavigationThemeProvider } from '@react-navigation/native';
-import { Stack } from 'expo-router';
+import type { Session } from '@supabase/supabase-js';
+import { Stack, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
 import 'react-native-reanimated';
 
+import { supabase } from '@/lib/supabase';
 import { AppThemeProvider, useThemeContext } from '@/providers/theme-provider';
 
 export const unstable_settings = { anchor: '(tabs)' };
 
 function RootNavigator() {
   const { colorScheme } = useThemeContext();
+  const router = useRouter();
+  const segments = useSegments();
+  const [session, setSession] = useState<Session | null>(null);
+  const [checkingSession, setCheckingSession] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    supabase.auth
+      .getSession()
+      .then(({ data, error }) => {
+        if (!active) return;
+        if (error) {
+          console.warn('Failed to fetch auth session:', error.message ?? error);
+        }
+        setSession(data?.session ?? null);
+        setCheckingSession(false);
+      })
+      .catch((error: any) => {
+        if (!active) return;
+        console.warn('Failed to fetch auth session:', error?.message || error);
+        setSession(null);
+        setCheckingSession(false);
+      });
+
+    const { data: authListener } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      if (!active) return;
+      setSession(newSession ?? null);
+      setCheckingSession(false);
+    });
+
+    return () => {
+      active = false;
+      authListener?.subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (checkingSession) return;
+    const inAuthGroup = segments[0] === 'auth';
+    if (!session && !inAuthGroup) {
+      router.replace('/auth');
+    } else if (session && inAuthGroup) {
+      router.replace('/(tabs)');
+    }
+  }, [checkingSession, router, segments, session]);
+
+  const navigationTheme = useMemo(
+    () => (colorScheme === 'dark' ? DarkTheme : DefaultTheme),
+    [colorScheme]
+  );
+
+  if (checkingSession) {
+    return (
+      <NavigationThemeProvider value={navigationTheme}>
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: navigationTheme.colors.background,
+          }}
+        >
+          <ActivityIndicator />
+        </View>
+        <StatusBar style="auto" />
+      </NavigationThemeProvider>
+    );
+  }
 
   return (
-    <NavigationThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+    <NavigationThemeProvider value={navigationTheme}>
       <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
-        <Stack.Screen name="user/[handle]" options={{ title: 'Athlete' }} />
+        {session ? (
+          <>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
+            <Stack.Screen name="user/[handle]" options={{ title: 'Athlete' }} />
+          </>
+        ) : (
+          <Stack.Screen name="auth" options={{ headerShown: false }} />
+        )}
       </Stack>
       <StatusBar style="auto" />
     </NavigationThemeProvider>

--- a/strength_rank/app/auth/_layout.tsx
+++ b/strength_rank/app/auth/_layout.tsx
@@ -1,0 +1,11 @@
+import { Stack } from 'expo-router';
+import React from 'react';
+
+export default function AuthLayout() {
+  return (
+    <Stack screenOptions={{ headerTitleAlign: 'center' }}>
+      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen name="sign-up" options={{ title: 'Create account' }} />
+    </Stack>
+  );
+}

--- a/strength_rank/app/auth/index.tsx
+++ b/strength_rank/app/auth/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './sign-in';

--- a/strength_rank/app/auth/sign-in.tsx
+++ b/strength_rank/app/auth/sign-in.tsx
@@ -1,0 +1,181 @@
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
+import { Link } from 'expo-router';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Colors } from '@/constants/theme';
+import { supabase } from '@/lib/supabase';
+import { useThemeContext } from '@/providers/theme-provider';
+
+export default function SignInScreen() {
+  const { colorScheme } = useThemeContext();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const passwordRef = useRef<TextInput>(null);
+
+  const themeColors = Colors[colorScheme];
+  const borderColor = colorScheme === 'dark' ? '#3f3f46' : '#d4d4d8';
+  const inputBackground = colorScheme === 'dark' ? '#1f1f23' : '#f9fafb';
+
+  const handleSignIn = useCallback(async () => {
+    if (!email.trim() || !password) {
+      setErrorMessage('Enter your email and password.');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setErrorMessage(null);
+      const { error } = await supabase.auth.signInWithPassword({
+        email: email.trim(),
+        password,
+      });
+      if (error) {
+        setErrorMessage(error.message ?? 'Could not sign in.');
+      }
+    } catch (error: any) {
+      setErrorMessage(error?.message || 'Could not sign in.');
+    } finally {
+      setLoading(false);
+    }
+  }, [email, password]);
+
+  return (
+    <ThemedView style={styles.container}>
+      <KeyboardAvoidingView
+        behavior={Platform.select({ ios: 'padding', default: undefined })}
+        style={{ flex: 1 }}
+      >
+        <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+          <View style={styles.header}>
+            <ThemedText type="title">Welcome back</ThemedText>
+            <ThemedText style={styles.subtitle}>Sign in to continue your training journey.</ThemedText>
+          </View>
+
+          <View style={styles.form}>
+            <TextInput
+              value={email}
+              onChangeText={setEmail}
+              placeholder="you@example.com"
+              placeholderTextColor={colorScheme === 'dark' ? '#71717a' : '#a1a1aa'}
+              autoCapitalize="none"
+              keyboardType="email-address"
+              autoComplete="email"
+              textContentType="emailAddress"
+              style={[
+                styles.input,
+                {
+                  backgroundColor: inputBackground,
+                  borderColor,
+                  color: themeColors.text,
+                },
+              ]}
+              editable={!loading}
+              returnKeyType="next"
+              onSubmitEditing={() => {
+                if (!loading) {
+                  passwordRef.current?.focus?.();
+                }
+              }}
+            />
+            <TextInput
+              ref={passwordRef}
+              value={password}
+              onChangeText={setPassword}
+              placeholder="Password"
+              placeholderTextColor={colorScheme === 'dark' ? '#71717a' : '#a1a1aa'}
+              secureTextEntry
+              textContentType="password"
+              style={[
+                styles.input,
+                {
+                  backgroundColor: inputBackground,
+                  borderColor,
+                  color: themeColors.text,
+                },
+              ]}
+              editable={!loading}
+              returnKeyType="done"
+              onSubmitEditing={() => {
+                if (!loading) handleSignIn();
+              }}
+            />
+
+            {errorMessage ? <ThemedText style={styles.error}>{errorMessage}</ThemedText> : null}
+
+            <Pressable
+              accessibilityRole="button"
+              onPress={handleSignIn}
+              style={[styles.primaryButton, { backgroundColor: themeColors.tint }]}
+              disabled={loading}
+            >
+              {loading ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <ThemedText style={styles.primaryButtonText}>Sign in</ThemedText>
+              )}
+            </Pressable>
+          </View>
+
+          <View style={styles.footer}>
+            <ThemedText style={styles.footerText}>Need an account?</ThemedText>
+            <Link href="/auth/sign-up" replace style={[styles.footerLink, { color: themeColors.tint }]}>
+              Create one
+            </Link>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingHorizontal: 20, paddingTop: Platform.select({ ios: 60, android: 40, default: 32 }) },
+  scroll: { flexGrow: 1, justifyContent: 'space-between' },
+  header: { gap: 8 },
+  subtitle: { opacity: 0.7 },
+  form: { marginTop: 32, gap: 16 },
+  input: {
+    paddingHorizontal: 16,
+    paddingVertical: Platform.select({ ios: 14, android: 10, default: 12 }),
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 16,
+  },
+  error: {
+    color: '#ef4444',
+    textAlign: 'center',
+  },
+  primaryButton: {
+    marginTop: 8,
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  footer: {
+    marginTop: 32,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 6,
+    alignItems: 'center',
+  },
+  footerText: { opacity: 0.7 },
+  footerLink: { fontWeight: '600' },
+});

--- a/strength_rank/app/auth/sign-up.tsx
+++ b/strength_rank/app/auth/sign-up.tsx
@@ -1,0 +1,216 @@
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
+import { Link } from 'expo-router';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Colors } from '@/constants/theme';
+import { supabase } from '@/lib/supabase';
+import { useThemeContext } from '@/providers/theme-provider';
+
+export default function SignUpScreen() {
+  const { colorScheme } = useThemeContext();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [infoMessage, setInfoMessage] = useState<string | null>(null);
+
+  const passwordRef = useRef<TextInput>(null);
+  const confirmRef = useRef<TextInput>(null);
+
+  const themeColors = Colors[colorScheme];
+  const borderColor = colorScheme === 'dark' ? '#3f3f46' : '#d4d4d8';
+  const inputBackground = colorScheme === 'dark' ? '#1f1f23' : '#f9fafb';
+
+  const handleSignUp = useCallback(async () => {
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail || !password || !confirmPassword) {
+      setErrorMessage('Fill in all fields to continue.');
+      return;
+    }
+    if (password.length < 6) {
+      setErrorMessage('Password must be at least 6 characters long.');
+      return;
+    }
+    if (password !== confirmPassword) {
+      setErrorMessage('Passwords do not match.');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setErrorMessage(null);
+      setInfoMessage(null);
+      const { error } = await supabase.auth.signUp({
+        email: trimmedEmail,
+        password,
+      });
+      if (error) {
+        setErrorMessage(error.message ?? 'Could not create your account.');
+      } else {
+        setInfoMessage('Check your email for a confirmation link to finish signing up.');
+      }
+    } catch (error: any) {
+      setErrorMessage(error?.message || 'Could not create your account.');
+    } finally {
+      setLoading(false);
+    }
+  }, [confirmPassword, email, password]);
+
+  return (
+    <ThemedView style={styles.container}>
+      <KeyboardAvoidingView
+        behavior={Platform.select({ ios: 'padding', default: undefined })}
+        style={{ flex: 1 }}
+      >
+        <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+          <View style={styles.header}>
+            <ThemedText type="title">Create your account</ThemedText>
+            <ThemedText style={styles.subtitle}>Join Strength Rank and start tracking your lifts.</ThemedText>
+          </View>
+
+          <View style={styles.form}>
+            <TextInput
+              value={email}
+              onChangeText={setEmail}
+              placeholder="you@example.com"
+              placeholderTextColor={colorScheme === 'dark' ? '#71717a' : '#a1a1aa'}
+              autoCapitalize="none"
+              keyboardType="email-address"
+              autoComplete="email"
+              textContentType="emailAddress"
+              style={[
+                styles.input,
+                {
+                  backgroundColor: inputBackground,
+                  borderColor,
+                  color: themeColors.text,
+                },
+              ]}
+              editable={!loading}
+              returnKeyType="next"
+              onSubmitEditing={() => passwordRef.current?.focus?.()}
+            />
+            <TextInput
+              ref={passwordRef}
+              value={password}
+              onChangeText={setPassword}
+              placeholder="Password"
+              placeholderTextColor={colorScheme === 'dark' ? '#71717a' : '#a1a1aa'}
+              secureTextEntry
+              textContentType="newPassword"
+              style={[
+                styles.input,
+                {
+                  backgroundColor: inputBackground,
+                  borderColor,
+                  color: themeColors.text,
+                },
+              ]}
+              editable={!loading}
+              returnKeyType="next"
+              onSubmitEditing={() => confirmRef.current?.focus?.()}
+            />
+            <TextInput
+              ref={confirmRef}
+              value={confirmPassword}
+              onChangeText={setConfirmPassword}
+              placeholder="Confirm password"
+              placeholderTextColor={colorScheme === 'dark' ? '#71717a' : '#a1a1aa'}
+              secureTextEntry
+              textContentType="password"
+              style={[
+                styles.input,
+                {
+                  backgroundColor: inputBackground,
+                  borderColor,
+                  color: themeColors.text,
+                },
+              ]}
+              editable={!loading}
+              returnKeyType="done"
+              onSubmitEditing={() => {
+                if (!loading) handleSignUp();
+              }}
+            />
+
+            {errorMessage ? <ThemedText style={styles.error}>{errorMessage}</ThemedText> : null}
+            {infoMessage ? <ThemedText style={styles.info}>{infoMessage}</ThemedText> : null}
+
+            <Pressable
+              accessibilityRole="button"
+              onPress={handleSignUp}
+              style={[styles.primaryButton, { backgroundColor: themeColors.tint }]}
+              disabled={loading}
+            >
+              {loading ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <ThemedText style={styles.primaryButtonText}>Sign up</ThemedText>
+              )}
+            </Pressable>
+          </View>
+
+          <View style={styles.footer}>
+            <ThemedText style={styles.footerText}>Already have an account?</ThemedText>
+            <Link href="/auth" replace style={[styles.footerLink, { color: themeColors.tint }]}>Sign in</Link>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingHorizontal: 20, paddingTop: Platform.select({ ios: 60, android: 40, default: 32 }) },
+  scroll: { flexGrow: 1, justifyContent: 'space-between' },
+  header: { gap: 8 },
+  subtitle: { opacity: 0.7 },
+  form: { marginTop: 32, gap: 16 },
+  input: {
+    paddingHorizontal: 16,
+    paddingVertical: Platform.select({ ios: 14, android: 10, default: 12 }),
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 16,
+  },
+  error: {
+    color: '#ef4444',
+    textAlign: 'center',
+  },
+  info: {
+    color: '#22c55e',
+    textAlign: 'center',
+  },
+  primaryButton: {
+    marginTop: 8,
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  footer: {
+    marginTop: 32,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 6,
+    alignItems: 'center',
+  },
+  footerText: { opacity: 0.7 },
+  footerLink: { fontWeight: '600' },
+});

--- a/strength_rank/lib/auth.ts
+++ b/strength_rank/lib/auth.ts
@@ -1,57 +1,29 @@
 import { supabase } from './supabase';
-import { devSignIn, getDevUserId } from './data';
 
 type NullableUserId = string | null;
 
 /** Ensure the current client is authenticated and return the user id if possible. */
 export async function ensureSignedIn(): Promise<NullableUserId> {
-  const { data } = await supabase.auth.getUser();
-  if (data?.user?.id) return data.user.id;
+  const [{ data: sessionData, error: sessionError }, { data: userData, error: userError }] = await Promise.all([
+    supabase.auth.getSession(),
+    supabase.auth.getUser(),
+  ]);
 
-  try {
-    await devSignIn();
-  } catch {
-    // ignore
-  }
+  if (sessionError) throw sessionError;
+  if (userError) throw userError;
 
-  const again = await supabase.auth.getUser();
-  if (again.data?.user?.id) return again.data.user.id;
-
-  try {
-    const id = await getDevUserId();
-    if (id) return id;
-  } catch {
-    // ignore
-  }
-
-  try {
-    const { data: you } = await supabase.from('profiles').select('id').eq('handle', '@you').single();
-    if (you?.id) return you.id;
-  } catch {
-    // ignore
-  }
-
-  return null;
+  return sessionData?.session?.user?.id ?? userData?.user?.id ?? null;
 }
 
 /** Resolve the current user's id if known without forcing a sign-in. */
 export async function resolveCurrentUserId(): Promise<NullableUserId> {
-  const { data } = await supabase.auth.getUser();
-  if (data?.user?.id) return data.user.id;
+  const { data, error } = await supabase.auth.getUser();
+  if (error) throw error;
+  return data?.user?.id ?? null;
+}
 
-  try {
-    const id = await getDevUserId();
-    if (id) return id;
-  } catch {
-    // ignore
-  }
-
-  try {
-    const { data: you } = await supabase.from('profiles').select('id').eq('handle', '@you').single();
-    if (you?.id) return you.id;
-  } catch {
-    // ignore
-  }
-
-  return null;
+/** Sign the current session out. */
+export async function signOut(): Promise<void> {
+  const { error } = await supabase.auth.signOut();
+  if (error) throw error;
 }


### PR DESCRIPTION
## Summary
- add Supabase email/password sign-in and sign-up screens with loading and error states
- gate the root navigator on real Supabase sessions and expose a loader while checking auth
- refactor profile/auth helpers to rely on live sessions and add a profile sign-out action

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d92581b3d48329acc7ce3c8a87a8ce